### PR TITLE
upgrade cuda 12.6.3 and gcr image 0.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # building contaienr for https://github.com/comfyanonymous/ComfyUI
-FROM docker.io/nvidia/cuda:12.6.2-base-ubuntu24.04
+FROM docker.io/nvidia/cuda:12.6.3-base-ubuntu24.04
 WORKDIR /app
 
 # install curl and git

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo chown $USER /models
 ./scripts/download_models.sh
 
 # start container (inference time will be printed on console)
-podman run --security-opt=label=disable --gpus=all -p 8188:8188 -v /models:/app/models -v /tmp/output:/app/output  --name=comfyui  gcr.io/$PROJECT_NAME/comfyui-checkpoint:0.0.3
+podman run --security-opt=label=disable --gpus=all -p 8188:8188 -v /models:/app/models -v /tmp/output:/app/output  --name=comfyui  gcr.io/$PROJECT_NAME/comfyui-checkpoint:0.0.4
 
 # execute inference
  ./scripts/generate_image.sh
@@ -76,9 +76,9 @@ building the image - you shuold provide your own `PROJECT_NAME`
 ```bash
 export PROJECT_NAME=<your-project-name>
 
-podman build . -t gcr.io/$PROJECT_NAME/comfyui-checkpoint:0.0.3
+podman build . -t gcr.io/$PROJECT_NAME/comfyui-checkpoint:0.0.4
 
-podman push gcr.io/$PROJECT_NAME/comfyui-checkpoint:0.0.3
+podman push gcr.io/$PROJECT_NAME/comfyui-checkpoint:0.0.4
 ```
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@ namespace: $NAMESPACE
 
 image:
   repository: gcr.io/$PROJECT_NAME/comfyui-checkpoint
-  tag: "0.0.3"
+  tag: "0.0.4"
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## CUDA 12.6.3 upgrade
- upgrading to `docker.io/nvidia/cuda:12.6.3-base-ubuntu24.04` (driver version 560)